### PR TITLE
 Add method to fetch instance current spot price

### DIFF
--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -27,7 +27,7 @@ type AWSInstance struct {
 	Type             string
 }
 
-// GetAWSInstanceInfo fetches current price of an instance.
+// GetAWSInstanceInfo fetches current hourly price of an instance.
 func (instance *AWSInstance) GetHourlyPrice() (float64, bool, error) {
 	var (
 		pricePerHour float64
@@ -95,7 +95,7 @@ func GetAWSInstanceInfo(id string, region string) (AWSInstance, error) {
 	return instance, nil
 }
 
-// GetAWSInstanceOnDemandHourlyPrice fetches current AWS on-demand price of an instance.
+// GetAWSInstanceOnDemandHourlyPrice fetches current hourly AWS on-demand price of an instance.
 func GetAWSInstanceOnDemandHourlyPrice(instance *AWSInstance) (float64, bool, error) {
 	var pricePerHour float64
 	var priceFound bool
@@ -123,7 +123,7 @@ func GetAWSInstanceOnDemandHourlyPrice(instance *AWSInstance) (float64, bool, er
 	return pricePerHour, priceFound, nil
 }
 
-// GetAWSInstanceSpotHourlyPrice fetches current AWS spot price of an instance.
+// GetAWSInstanceSpotHourlyPrice fetches current hourly AWS spot price of an instance.
 func GetAWSInstanceSpotHourlyPrice(instance *AWSInstance) (float64, bool, error) {
 	var pricePerHour float64
 	var priceFound bool

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -24,6 +25,25 @@ type AWSInstance struct {
 	Lifecycle        string
 	Region           string
 	Type             string
+}
+
+func (instance *AWSInstance) GetHourlyPrice() (float64, bool, error) {
+	var (
+		pricePerHour float64
+		priceFound   bool
+		err          error
+	)
+
+	switch instance.Lifecycle {
+	case "scheduled":
+		pricePerHour, priceFound, err = GetAWSInstanceOnDemandHourlyPrice(instance)
+	case "spot":
+		pricePerHour, priceFound, err = GetAWSInstanceSpotHourlyPrice(instance)
+	default:
+		err = errors.New("invalid lifecycle")
+	}
+
+	return pricePerHour, priceFound, err
 }
 
 // GetAWSInstanceInfo gets information on an AWS instance

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -27,7 +27,7 @@ type AWSInstance struct {
 	Type             string
 }
 
-// GetAWSInstanceInfo fetches current hourly price of an instance.
+// GetHourlyPrice fetches current hourly price of an instance.
 func (instance *AWSInstance) GetHourlyPrice() (float64, bool, error) {
 	var (
 		pricePerHour float64

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -17,11 +18,12 @@ type AWSEBSVolume struct {
 
 // AWSInstance is an AWS EBS instance
 type AWSInstance struct {
-	ID         string
-	EBSVolumes []AWSEBSVolume
-	Lifecycle  string
-	Region     string
-	Type       string
+	ID               string
+	AvailabilityZone string
+	EBSVolumes       []AWSEBSVolume
+	Lifecycle        string
+	Region           string
+	Type             string
 }
 
 // GetAWSInstanceInfo gets information on an AWS instance
@@ -61,11 +63,12 @@ func GetAWSInstanceInfo(id string, region string) (AWSInstance, error) {
 	}
 
 	instance = AWSInstance{
-		ID:         *result.Reservations[0].Instances[0].InstanceId,
-		EBSVolumes: ebsVolumes,
-		Lifecycle:  lifecycle,
-		Region:     region,
-		Type:       *result.Reservations[0].Instances[0].InstanceType,
+		ID:               *result.Reservations[0].Instances[0].InstanceId,
+		AvailabilityZone: *result.Reservations[0].Instances[0].Placement.AvailabilityZone,
+		EBSVolumes:       ebsVolumes,
+		Lifecycle:        lifecycle,
+		Region:           region,
+		Type:             *result.Reservations[0].Instances[0].InstanceType,
 	}
 
 	return instance, nil
@@ -94,6 +97,61 @@ func GetAWSInstanceOnDemandHourlyPrice(instance *AWSInstance) (float64, bool, er
 
 			break
 		}
+	}
+
+	return pricePerHour, priceFound, nil
+}
+
+// GetAWSInstanceSpotHourlyPrice fetches current AWS spot price of an instance.
+func GetAWSInstanceSpotHourlyPrice(instance *AWSInstance) (float64, bool, error) {
+	var pricePerHour float64
+	var priceFound bool
+
+	sess := session.Must(session.NewSession(&aws.Config{Region: aws.String(instance.Region)}))
+	svc := ec2.New(sess)
+	input := &ec2.DescribeSpotPriceHistoryInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("availability-zone"),
+				Values: []*string{
+					aws.String(instance.AvailabilityZone),
+				},
+			},
+			{
+				Name: aws.String("instance-type"),
+				Values: []*string{
+					aws.String(instance.Type),
+				},
+			},
+			{
+				Name: aws.String("product-description"),
+				Values: []*string{
+					aws.String("Linux/UNIX (Amazon VPC)"),
+				},
+			},
+		},
+	}
+
+	result, err := svc.DescribeSpotPriceHistory(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			fmt.Println(err.Error())
+		}
+		return pricePerHour, priceFound, err
+	}
+
+	if len(result.SpotPriceHistory) > 0 {
+		pricePerHour, err = strconv.ParseFloat(*result.SpotPriceHistory[0].SpotPrice, 64)
+		if err != nil {
+			return pricePerHour, priceFound, err
+		}
+
+		priceFound = true
 	}
 
 	return pricePerHour, priceFound, nil

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -19,6 +19,7 @@ type AWSEBSVolume struct {
 type AWSInstance struct {
 	ID         string
 	EBSVolumes []AWSEBSVolume
+	Lifecycle  string
 	Region     string
 	Type       string
 }
@@ -52,9 +53,17 @@ func GetAWSInstanceInfo(id string, region string) (AWSInstance, error) {
 		ebsVolumes = append(ebsVolumes, AWSEBSVolume{ID: *ebsVolume.Ebs.VolumeId})
 	}
 
+	lifecycle := ""
+	if result.Reservations[0].Instances[0].InstanceLifecycle == nil {
+		lifecycle = "scheduled"
+	} else {
+		lifecycle = "spot"
+	}
+
 	instance = AWSInstance{
 		ID:         *result.Reservations[0].Instances[0].InstanceId,
 		EBSVolumes: ebsVolumes,
+		Lifecycle:  lifecycle,
 		Region:     region,
 		Type:       *result.Reservations[0].Instances[0].InstanceType,
 	}

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -27,6 +27,7 @@ type AWSInstance struct {
 	Type             string
 }
 
+// GetAWSInstanceInfo fetches current price of an instance.
 func (instance *AWSInstance) GetHourlyPrice() (float64, bool, error) {
 	var (
 		pricePerHour float64


### PR DESCRIPTION
If instance is spot ... you can get it's spot instance hourly price

```go
region := "us-east-1"

onDemandNode, _ := cloud.GetAWSInstanceInfo("i-0b6c32a2cd9d6ae64", region)
onDemandPrice, _, _ := cloud.GetAWSInstanceOnDemandHourlyPrice(&onDemandNode)
fmt.Println(onDemandNode.Lifecycle)
// scheduled
fmt.Println(onDemandNode, onDemandPrice)
// {i-0b6c32a2cd9d6ae64 us-east-1e [{vol-0d60e6e542113bdcd}] scheduled us-east-1 t2.micro <nil>} 0.0116

spotNode, _ := cloud.GetAWSInstanceInfo("i-032cf8b5268adb310", region)
spotPrice, _, _ := cloud.GetAWSInstanceSpotHourlyPrice(&spotNode)
fmt.Println(spotNode)
// spot
fmt.Println(spotNode, spotPrice)
// {i-032cf8b5268adb310 us-east-1b [{vol-00c4272235b6f2a90} {vol-0e2a92909807981ee}] spot us-east-1 r4.4xlarge 0xc42028b0a8} 0.3037
```

Also added `AvailabilityZone` field on the `AWSInstance` struct.