### PR TITLE
Account for node overhead costs and ship better granularity to influx

### DIFF
--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -130,13 +130,13 @@ func (cs *CostService) storePodCosts() {
 		total, _ := podInfo.cost.total.Float64()
 		utilization, _ := podInfo.cost.utilization.Float64()
 		underUtilization, _ := podInfo.cost.underUtilization.Float64()
-		nodOverhead, _ := podInfo.cost.nodeOverhead.Float64()
+		nodeOverhead, _ := podInfo.cost.nodeOverhead.Float64()
 
 		fields := map[string]interface{}{
 			"total":             total,
 			"utilization":       utilization,
 			"under_utilization": underUtilization,
-			"nod_overhead":      nodOverhead,
+			"node_overhead":     nodeOverhead,
 		}
 
 		pt, err := client.NewPoint("cost", tags, fields, time.Now())

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -20,20 +20,10 @@ type CostService struct {
 
 // PodCostComponents struct to hold all the cost information for a single pod
 type PodCostComponents struct {
-	totalCost        decimal.Decimal
+	total            decimal.Decimal
 	utilization      decimal.Decimal
 	underUtilization decimal.Decimal
 	nodeOverhead     decimal.Decimal
-}
-
-// NewPodCostComponents creates a new PodCostComponents
-func NewPodCostComponents(totalCost decimal.Decimal, utilization decimal.Decimal, underUtilization decimal.Decimal, nodeOverhead decimal.Decimal) *PodCostComponents {
-	return &PodCostComponents{
-		totalCost:        totalCost,
-		utilization:      utilization,
-		underUtilization: underUtilization,
-		nodeOverhead:     nodeOverhead,
-	}
 }
 
 // NewCostService creates a new CostService
@@ -137,13 +127,13 @@ func (cs *CostService) storePodCosts() {
 		tags["node_name"] = podInfo.nodeName
 		tags["namespace"] = podInfo.namespace
 
-		totalCost, _ := podInfo.cost.totalCost.Float64()
+		total, _ := podInfo.cost.total.Float64()
 		utilization, _ := podInfo.cost.utilization.Float64()
 		underUtilization, _ := podInfo.cost.underUtilization.Float64()
 		nodOverhead, _ := podInfo.cost.nodeOverhead.Float64()
 
 		fields := map[string]interface{}{
-			"total_cost":        totalCost,
+			"total":             total,
 			"utilization":       utilization,
 			"under_utilization": underUtilization,
 			"nod_overhead":      nodOverhead,
@@ -203,7 +193,13 @@ func calculatePodCost(pod *podInfo, node *nodeInfo) (*PodCostComponents, error) 
 	underUtilization := podCPUUnderUtilizationCost.Add(podMemoryUnderUtilizationCost)
 	nodeOverhead := nodeCPUOverheadCost.Add(nodeMemoryOverheadCost)
 
-	totalCost := utilization.Add(underUtilization).Add(nodeOverhead)
+	total := utilization.Add(underUtilization).Add(nodeOverhead)
 
-	return NewPodCostComponents(totalCost, utilization, underUtilization, nodeOverhead), nil
+	podCostComponents := &PodCostComponents{
+		total:            total,
+		utilization:      utilization,
+		underUtilization: underUtilization,
+		nodeOverhead:     nodeOverhead,
+	}
+	return podCostComponents, nil
 }

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -186,12 +186,11 @@ func calculatePodCost(pod *podInfo, node *nodeInfo) (*PodCostComponents, error) 
 	podCPUUnderUtilizationCost := podCPUUtilizationFactor.Mul(nodeCPUUnderUtilization).Mul(nodeCPUCost)
 	podMemoryUnderUtilizationCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
 
-	nodeCPUOverheadCost := podCPUUtilizationFactor.Mul(nodeCPUUnderUtilization).Mul(nodeCPUCost)
 	nodeMemoryOverheadCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
 
 	utilization := podCPUUtilizationCost.Add(podMemoryUtilizationCost)
 	underUtilization := podCPUUnderUtilizationCost.Add(podMemoryUnderUtilizationCost)
-	nodeOverhead := nodeCPUOverheadCost.Add(nodeMemoryOverheadCost)
+	nodeOverhead := nodeMemoryOverheadCost
 
 	total := utilization.Add(underUtilization).Add(nodeOverhead)
 

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -186,7 +186,8 @@ func calculatePodCost(pod *podInfo, node *nodeInfo) (*PodCostComponents, error) 
 	podCPUUnderUtilizationCost := podCPUUtilizationFactor.Mul(nodeCPUUnderUtilization).Mul(nodeCPUCost)
 	podMemoryUnderUtilizationCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
 
-	nodeMemoryOverheadCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
+	nodeMemoryOverhead := decimal.NewFromFloat(float64(node.allocatableMemory) / float64(node.capacityMemory))
+	nodeMemoryOverheadCost := podMemoryUtilizationFactor.Mul(nodeMemoryOverhead).Mul(nodeMemoryCost)
 
 	utilization := podCPUUtilizationCost.Add(podMemoryUtilizationCost)
 	underUtilization := podCPUUnderUtilizationCost.Add(podMemoryUnderUtilizationCost)

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -186,7 +186,7 @@ func calculatePodCost(pod *podInfo, node *nodeInfo) (*PodCostComponents, error) 
 	podCPUUnderUtilizationCost := podCPUUtilizationFactor.Mul(nodeCPUUnderUtilization).Mul(nodeCPUCost)
 	podMemoryUnderUtilizationCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
 
-	nodeMemoryOverhead := decimal.NewFromFloat(float64(node.allocatableMemory) / float64(node.capacityMemory))
+	nodeMemoryOverhead := decimal.NewFromFloat(1 - float64(node.allocatableMemory)/float64(node.capacityMemory))
 	nodeMemoryOverheadCost := podMemoryUtilizationFactor.Mul(nodeMemoryOverhead).Mul(nodeMemoryCost)
 
 	utilization := podCPUUtilizationCost.Add(podMemoryUtilizationCost)

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -18,7 +18,7 @@ type CostService struct {
 	influxdbClient client.Client
 }
 
-// Struct to hold all the cost information for a single pod
+// PodCostComponents struct to hold all the cost information for a single pod
 type PodCostComponents struct {
 	totalCost        decimal.Decimal
 	utilization      decimal.Decimal
@@ -26,6 +26,7 @@ type PodCostComponents struct {
 	nodeOverhead     decimal.Decimal
 }
 
+// NewPodCostComponents creates a new PodCostComponents
 func NewPodCostComponents(totalCost decimal.Decimal, utilization decimal.Decimal, underUtilization decimal.Decimal, nodeOverhead decimal.Decimal) *PodCostComponents {
 	return &PodCostComponents{
 		totalCost:        totalCost,

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -172,6 +172,9 @@ func calculatePodCost(pod *podInfo, node *nodeInfo) (decimal.Decimal, error) {
 	podCPUUnderUtilizationCost := podCPUUtilizationFactor.Mul(nodeCPUUnderUtilization).Mul(nodeCPUCost)
 	podMemoryUnderUtilizationCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
 
+	nodeCPUOverheadCost := podCPUUtilizationFactor.Mul(nodeCPUUnderUtilization).Mul(nodeCPUCost)
+	nodeMemoryOverheadCost := podMemoryUtilizationFactor.Mul(nodeMemoryUnderUtilization).Mul(nodeMemoryCost)
+
 	podCPUCost := podCPUUtilizationCost.Add(podCPUUnderUtilizationCost)
 	podMemoryCost := podMemoryUtilizationCost.Add(podMemoryUnderUtilizationCost)
 

--- a/agent/kubernetes/service.go
+++ b/agent/kubernetes/service.go
@@ -139,14 +139,14 @@ func (cs *CostService) storePodCosts() {
 
 		totalCost, _ := podInfo.cost.totalCost.Float64()
 		utilization, _ := podInfo.cost.utilization.Float64()
-		under_utilization, _ := podInfo.cost.underUtilization.Float64()
-		nod_overhead, _ := podInfo.cost.nodeOverhead.Float64()
+		underUtilization, _ := podInfo.cost.underUtilization.Float64()
+		nodOverhead, _ := podInfo.cost.nodeOverhead.Float64()
 
 		fields := map[string]interface{}{
 			"total_cost":        totalCost,
 			"utilization":       utilization,
-			"under_utilization": under_utilization,
-			"nod_overhead":      nod_overhead,
+			"under_utilization": underUtilization,
+			"nod_overhead":      nodOverhead,
 		}
 
 		pt, err := client.NewPoint("cost", tags, fields, time.Now())

--- a/agent/kubernetes/types.go
+++ b/agent/kubernetes/types.go
@@ -22,5 +22,5 @@ type podInfo struct {
 	cpuRequest    int64
 	memoryRequest int64
 	nodeName      string
-	cost          decimal.Decimal
+	cost          *PodCostComponents
 }


### PR DESCRIPTION
Incorporates the node overhead costs into the pod costs.

Calculating the pod costs now returns a struct, containing the total pod cost and its components.